### PR TITLE
bugfix in movement - swimming in water without path did crashed the game

### DIFF
--- a/npcf/movement.lua
+++ b/npcf/movement.lua
@@ -199,7 +199,7 @@ function mvobj_proto:_do_movement_step(dtime)
 		if string.find(node[0].name, "^default:water") or
 		   string.find(node[1].name, "^default:water") then
 			-- we are under water. sink if target bellow the current position. otherwise swim up
-			if not self._path[1] or self._path[1].y > self.pos.y then
+			if not self._path or not self._path[1] or self._path[1].y > self.pos.y then
 				self.velocity.y = 3
 			end
 		end


### PR DESCRIPTION
I found a bug, if NPC is in water without path the game was crashed. Now the NPC just swimm up